### PR TITLE
Support for node v0.10 (1.1.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "node"
+  - "0.10"
   - "0.12"
   - "iojs"

--- a/index.js
+++ b/index.js
@@ -24,10 +24,9 @@ module.exports = function(rawDataDir) {
   var payload = {};
 
   files.forEach(function(file) {
-    var props = path.parse(file);
-    var extension = props.ext;
-    var basename = props.name;
-    var dir = path.normalize(props.dir);
+    var extension = path.extname(file);
+    var basename = path.basename(file, extension);
+    var dir = path.normalize(path.dirname(file));
 
     var data;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quaff",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Collect JSON/YAML/YML files from a source folder and convert them into a single object.",
   "repository": "rdmurphy/quaff",
   "author": "Ryan Murphy <ryan@rdmurphy.org>",
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Worked around the `path.parse()` convenience method that `node@v0.10` does not have by obtaining what it provides via other functions in the `path` module. There's a pretty good chance that's what `path.parse()` was doing behind the scenes anyway!