### PR TITLE
Throw error pointing to the invalid file

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,36 +25,40 @@ module.exports = function (rawDataDir) {
   const payload = {};
 
   files.forEach(function (file) {
-    const extension = path.extname(file);
-    const basename = path.basename(file, extension);
-    const dir = path.normalize(path.dirname(file));
-    const fileContents = fs.readFileSync(file, 'utf8');
+    try {
+      const extension = path.extname(file);
+      const basename = path.basename(file, extension);
+      const dir = path.normalize(path.dirname(file));
+      const fileContents = fs.readFileSync(file, 'utf8');
 
-    let data;
+      let data;
 
-    if (extension === '.json') {
-      data = JSON.parse(fileContents);
-    } else if (extension === '.yaml' || extension === '.yml') {
-      data = yaml.safeLoad(fileContents);
-    } else if (extension === '.csv') {
-      data = dsv.csv.parse(fileContents);
-    } else {
-      data = dsv.tsv.parse(fileContents);
-    }
-
-    let obj = payload;
-
-    const dirs = dir.split(path.sep);
-    dirs.splice(0, depth); // dump the root dataDir
-
-    dirs.forEach(function (dir) {
-      if (!obj.hasOwnProperty(dir)) {
-        obj[dir] = {};
+      if (extension === '.json') {
+        data = JSON.parse(fileContents);
+      } else if (extension === '.yaml' || extension === '.yml') {
+        data = yaml.safeLoad(fileContents);
+      } else if (extension === '.csv') {
+        data = dsv.csv.parse(fileContents);
+      } else {
+        data = dsv.tsv.parse(fileContents);
       }
-      obj = obj[dir];
-    });
 
-    obj[basename] = data;
+      let obj = payload;
+
+      const dirs = dir.split(path.sep);
+      dirs.splice(0, depth); // dump the root dataDir
+
+      dirs.forEach(function (dir) {
+        if (!obj.hasOwnProperty(dir)) {
+          obj[dir] = {};
+        }
+        obj = obj[dir];
+      });
+
+      obj[basename] = data;
+    } catch (error) {
+      throw new Error(`${error.message}. Error in ${file}.`)
+    }
   });
 
   return payload;

--- a/test/test.js
+++ b/test/test.js
@@ -9,10 +9,13 @@ const yaml = require('js-yaml');
 const dsv = require('d3-dsv');
 
 it('should throw an error pointing to the invalid file', function() {
+  let errorMessage;
   try {
     quaff('./test/source/empty_file/');
-  } catch (e) {
-    assert.equal(e.message, 'Unexpected end of JSON input. Error in test/source/empty_file/empty.json.');
+  } catch (error) {
+    errorMessage = error.message;
+  } finally {
+    assert(errorMessage.indexOf('Error in test/source/empty_file/empty.json.'));
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,14 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const dsv = require('d3-dsv');
 
+it('should throw an error pointing to the invalid file', function() {
+  try {
+    quaff('./test/source/empty_file/');
+  } catch (e) {
+    assert.equal(e.message, 'Unexpected end of JSON input. Error in test/source/empty_file/empty.json.');
+  }
+});
+
 it('should normalize a trailing extra slash', function() {
   assert.deepEqual(quaff('./test/source/basic_json/'), {
     corgis: JSON.parse(fs.readFileSync('./test/source/basic_json/corgis.json', 'utf8'))


### PR DESCRIPTION
This tiny PR catches an error and throws it again, adding the problematic filename to the error `message`. This way the user knows what file caused the error. At the moment all we get is something like 'Unexpected end of input`.